### PR TITLE
Don't ouput negative values to kitlist.2da unusability column

### DIFF
--- a/m7multikit/lib/multikit.tpp
+++ b/m7multikit/lib/multikit.tpp
@@ -50,26 +50,34 @@ BEGIN
 		~0~ ~1~ ~2~ ~3~ ~4~ ~5~ ~6~ ~7~ ~8~ ~9~
 		~a~ ~b~ ~c~ ~d~ ~e~ ~f~
 	END
-	ACTION_IF ("%number%" == 0) BEGIN
-		OUTER_SPRINT "hexstr" "0x00000000"
-	END ELSE BEGIN
-		OUTER_SPRINT "sign" ""
-		OUTER_SET "num" = "%number%"
-		ACTION_IF ("%num%" < 0) BEGIN
-			OUTER_SPRINT "sign" "-"
-			OUTER_SET "num" = 0 - "%num%"
+	ACTION_MATCH number
+	WITH
+		0
+		BEGIN
+			OUTER_SPRINT "hexstr" "0x00000000"
 		END
-		OUTER_SPRINT "hexstr" ""
-		OUTER_WHILE ("%num%" > 0) BEGIN
-			OUTER_SET "digit" = ("%num%" & 15)
-			OUTER_SET "%num%" >>= 4
-			OUTER_SPRINT "hexdigit" $hexdigits("%digit%")
-			OUTER_SPRINT "hexstr" "%hexdigit%%hexstr%"
+		0xFFFFFFFF BEGIN
+			OUTER_SPRINT "hexstr" "0xFFFFFFFF"
 		END
-		OUTER_WHILE ((STRING_LENGTH "%hexstr%") < 8) BEGIN
-			OUTER_SPRINT "hexstr" "0%hexstr%"
-		END
-		OUTER_SPRINT "hexstr" "%sign%0x%hexstr%"
+		DEFAULT
+			OUTER_SET "num" = "%number%"
+			ACTION_IF ("%num%" < 0) BEGIN
+				OUTER_SET "absolute" = 0 - num
+				OUTER_SET "one_complement" = BNOT absolute
+				OUTER_SET "two_complement" = one_complement + 1
+				OUTER_SET "num" = two_complement
+			END
+			OUTER_SPRINT "hexstr" ""
+			OUTER_WHILE ("%num%" != 0) BEGIN
+				OUTER_SET "digit" = ("%num%" & 15)
+				OUTER_SET "%num%" >>= 4
+				OUTER_SPRINT "hexdigit" $hexdigits("%digit%")
+				OUTER_SPRINT "hexstr" "%hexdigit%%hexstr%"
+			END
+			OUTER_WHILE ((STRING_LENGTH "%hexstr%") < 8) BEGIN
+				OUTER_SPRINT "hexstr" "0%hexstr%"
+			END
+			OUTER_SPRINT "hexstr" "0x%hexstr%"
 	END
 END 
 
@@ -1935,7 +1943,7 @@ STRING_LENGTH kitid == 0~
 		ACTION_IF !ENGINE_IS tob BEGIN
 			COPY_EXISTING - xpbonus.2da override
 				COUNT_2DA_COLS colsn
-			    	READ_2DA_ENTRY 2 1 colsn lvl1xp
+				READ_2DA_ENTRY 2 1 colsn lvl1xp
 				READ_2DA_ENTRY 2 2 colsn lvl2xp
 				READ_2DA_ENTRY 2 7 colsn lvl7xp
 				wild_mage_xp_remove = (0 - lvl1xp) + (0 - lvl2xp) + (0 - lvl7xp)


### PR DESCRIPTION
kitlist.2da unusability is a bit field, we shouldn't output negative values to this field.
When I tested it (linux, in a BG:EEinstal) this seemed to trip the game executable. it saw the kit and proposed it on character creation, but under the generic base multiclass name (e.g. Cleric/Mage instead of Tempus/Entropist) and the character didn't have either of the kit applied.


So this column is treated a anunsigned int. This can happen when multikitting a wild mage (flag 0x80000000) where previously we would get '0x80000000'(string) BOR 0 -> -2 147 483 648 then only negative values after

This doesn't change the processing of 'positive' values (those with first bit set to zero) nor the actual bitfield computations, only the formatting of the result to kitlist.2da.